### PR TITLE
Start using abi3-py310

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = ["numpy~=2.3"]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = ["sphinx", "esbonio", "shibuya", "numpydoc", "pandas"]

--- a/symscan-py/Cargo.toml
+++ b/symscan-py/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/yutanagano/symscan"
 
 [dependencies]
 symscan = { version = "0.7", path = "../symscan/" }
-pyo3 = "0.27"
+pyo3 = { version = "0.27", features = ["abi3-py310"] }
 numpy = "0.27"
 
 [lib]


### PR DESCRIPTION
In order to mitigate situations where the end user may end up needing to self-compile the package for the newest Python versions, symscan switches to using the stable Python ABI. This means that we compile the package once, and this will be usable on any future Python version.